### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/src/ua-machine.ts
+++ b/src/ua-machine.ts
@@ -305,7 +305,16 @@ export class UaMachineryMachine {
                         referenceTypeId: ReferenceTypeIds.HasComponent
                     } as BrowseDescriptionLike)
                     if (isStatusCodeGoodish(monitoringBrowseResults.statusCode)) {
-                        if (this.namespaceArray.includes("http://opcfoundation.org/UA/Machinery/ProcessValues/")) {
+                        const allowedHosts = ["opcfoundation.org"];
+                        const isAllowedNamespace = this.namespaceArray.some(namespace => {
+                            try {
+                                const url = new URL(namespace);
+                                return allowedHosts.includes(url.host);
+                            } catch (e) {
+                                return false;
+                            }
+                        });
+                        if (isAllowedNamespace) {
                             for (let index = 0; index < monitoringBrowseResults.references!.length; index++) {
                                 const id = makeNodeIdStringFromExpandedNodeId(monitoringBrowseResults.references![index].nodeId);
                                 await this.loadProcessValue(id)


### PR DESCRIPTION
Potential fix for [https://github.com/umati/opcua-machinery-client/security/code-scanning/1](https://github.com/umati/opcua-machinery-client/security/code-scanning/1)

To fix the problem, we need to ensure that the URL is parsed and its host is checked against a whitelist of allowed hosts. This will prevent attackers from embedding the allowed host in unexpected parts of the URL.

- Parse each URL in `this.namespaceArray` to extract the host.
- Check if the host is in a predefined list of allowed hosts.
- Replace the substring check with this more robust validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
